### PR TITLE
Support json parsing into inline fixtures

### DIFF
--- a/spec/Knp/FriendlyContexts/Utils/TextFormaterSpec.php
+++ b/spec/Knp/FriendlyContexts/Utils/TextFormaterSpec.php
@@ -41,12 +41,13 @@ class TextFormaterSpec extends ObjectBehavior
         $this->tableToString($table)->shouldReturn($return);
     }
 
-    function it_should_return_array_from_list()
+    function it_should_return_array_from_list_formatted_as_string()
     {
-        $list = 'foo, bar, baz';
-
-        $this->listToArray($list)->shouldReturn(['foo', 'bar', 'baz']);
+        $this->listToArray('1')->shouldReturn(['1']);
+        $this->listToArray('foo, bar, baz')->shouldReturn(['foo', 'bar', 'baz']);
+        $this->listToArray('true')->shouldReturn(['true']);
     }
+
 
     function it_should_return_php_array_from_valid_json()
     {

--- a/spec/Knp/FriendlyContexts/Utils/TextFormaterSpec.php
+++ b/spec/Knp/FriendlyContexts/Utils/TextFormaterSpec.php
@@ -40,4 +40,18 @@ class TextFormaterSpec extends ObjectBehavior
 
         $this->tableToString($table)->shouldReturn($return);
     }
+
+    function it_should_return_array_from_list()
+    {
+        $list = 'foo, bar, baz';
+
+        $this->listToArray($list)->shouldReturn(['foo', 'bar', 'baz']);
+    }
+
+    function it_should_return_php_array_from_valid_json()
+    {
+        $json = '{"foo": {"bar": "baz"}}';
+
+        $this->listToArray($json)->shouldReturn(["foo" => ["bar" => "baz"]]);
+    }
 }

--- a/src/Knp/FriendlyContexts/Utils/TextFormater.php
+++ b/src/Knp/FriendlyContexts/Utils/TextFormater.php
@@ -54,9 +54,9 @@ class TextFormater
 
     public function listToArray($list, $delimiters = [', ', ' and '], $parser = "#||#")
     {
-        $json = json_decode($list, true);
+        $arrayFromJson = json_decode($list, true);
         if (json_last_error() === JSON_ERROR_NONE) {
-            return $json;
+            return $arrayFromJson;
         }
 
         $list  = str_replace('"', '', $list);

--- a/src/Knp/FriendlyContexts/Utils/TextFormater.php
+++ b/src/Knp/FriendlyContexts/Utils/TextFormater.php
@@ -54,9 +54,12 @@ class TextFormater
 
     public function listToArray($list, $delimiters = [', ', ' and '], $parser = "#||#")
     {
-        $arrayFromJson = json_decode($list, true);
-        if (json_last_error() === JSON_ERROR_NONE) {
-            return $arrayFromJson;
+        // we have a dirty workaround there but it's intended.
+        if (!is_numeric($list) && !in_array($list, ['true', 'false'], true)) {
+            $resultFromJson = json_decode($list, true);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                return $resultFromJson;
+            }
         }
 
         $list  = str_replace('"', '', $list);

--- a/src/Knp/FriendlyContexts/Utils/TextFormater.php
+++ b/src/Knp/FriendlyContexts/Utils/TextFormater.php
@@ -54,6 +54,11 @@ class TextFormater
 
     public function listToArray($list, $delimiters = [', ', ' and '], $parser = "#||#")
     {
+        $json = json_decode($list, true);
+        if (json_last_error() === JSON_ERROR_NONE) {
+            return $json;
+        }
+
         $list  = str_replace('"', '', $list);
 
         foreach ($delimiters as $delimiter) {


### PR DESCRIPTION
This implementation should not introduce any BC break.

If the json parsing does not occur perfectly, it uses the normal system to construct an array.